### PR TITLE
Runnig Voxtral evals

### DIFF
--- a/voxtral/run_eval.py
+++ b/voxtral/run_eval.py
@@ -1,0 +1,193 @@
+import argparse
+import os
+import soundfile
+import librosa
+import tempfile
+import torch
+from transformers import AutoProcessor, VoxtralForConditionalGeneration
+import evaluate
+from normalizer import data_utils
+import time
+from tqdm import tqdm
+
+wer_metric = evaluate.load("wer")
+torch.set_float32_matmul_precision('high')
+
+def main(args):
+
+
+    processor = AutoProcessor.from_pretrained(args.model_id)
+    model = VoxtralForConditionalGeneration.from_pretrained(args.model_id, torch_dtype=torch.bfloat16, device_map=args.device)
+
+    def benchmark(batch):
+        # Load audio inputs
+        audios = [audio["array"] for audio in batch["audio"]]
+        minibatch_size = len(audios)
+        sampling_rate = [audio["sampling_rate"] for audio in batch["audio"]]
+
+        paths = []
+
+        for i in range(len(audios)):
+            tmp = tempfile.NamedTemporaryFile(suffix='.wav', delete=False, delete_on_close=False)
+            soundfile.write(tmp.name, audios[i], samplerate=sampling_rate[i])
+            paths.append(tmp.name)
+        inputs = processor.apply_transcrition_request(audio=paths,
+                                                      language="en",
+                                                      model_id=args.model_id,
+                                                      )
+        inputs = inputs.to(args.device, dtype=torch.bfloat16)
+
+        start_time = time.time()
+        outputs = model.generate(**inputs, max_new_tokens=500)
+
+        output_text = processor.batch_decode(outputs[:, inputs.input_ids.shape[1]:], skip_special_tokens=True)
+        # END TIMING
+        runtime = time.time() - start_time
+
+        for p in paths:
+            print(f'Deleting {p}')
+            os.unlink(p)
+
+
+        # normalize by minibatch size since we want the per-sample time
+        batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]
+
+        # normalize transcriptions with English normalizer
+        batch["predictions"] = [data_utils.normalizer(pred) for pred in output_text]
+        batch["references"] = batch["norm_text"]
+        return batch
+
+    if args.warmup_steps is not None:
+        dataset = data_utils.load_data(args)
+        dataset = data_utils.prepare_data(dataset)
+
+        num_warmup_samples = args.warmup_steps * args.batch_size
+        if args.streaming:
+            warmup_dataset = dataset.take(num_warmup_samples)
+        else:
+            warmup_dataset = dataset.select(range(min(num_warmup_samples, len(dataset))))
+        warmup_dataset = iter(warmup_dataset.map(benchmark, batch_size=args.batch_size, batched=True, fn_kwargs={"min_new_tokens": args.max_new_tokens}))
+
+        for _ in tqdm(warmup_dataset, desc="Warming up..."):
+            continue
+
+    dataset = data_utils.load_data(args)
+    if args.max_eval_samples is not None and args.max_eval_samples > 0:
+        print(f"Subsampling dataset to first {args.max_eval_samples} samples!")
+        if args.streaming:
+            dataset = dataset.take(args.max_eval_samples)
+        else:
+            dataset = dataset.select(range(min(args.max_eval_samples, len(dataset))))
+    dataset = data_utils.prepare_data(dataset)
+
+    dataset = dataset.map(
+        benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
+    )
+
+    all_results = {
+        "audio_length_s": [],
+        "transcription_time_s": [],
+        "predictions": [],
+        "references": [],
+    }
+    result_iter = iter(dataset)
+    for result in tqdm(result_iter, desc="Samples..."):
+        for key in all_results:
+            all_results[key].append(result[key])
+
+    # Write manifest results (WER and RTFX)
+    manifest_path = data_utils.write_manifest(
+        all_results["references"],
+        all_results["predictions"],
+        args.model_id,
+        args.dataset_path,
+        args.dataset,
+        args.split,
+        audio_length=all_results["audio_length_s"],
+        transcription_time=all_results["transcription_time_s"],
+    )
+    print("Results saved at path:", os.path.abspath(manifest_path))
+
+    wer = wer_metric.compute(
+        references=all_results["references"], predictions=all_results["predictions"]
+    )
+    wer = round(100 * wer, 2)
+    rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
+    print("WER:", wer, "%", "RTFx:", rtfx)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        required=True,
+        help="Model identifier. Should be loadable with 🤗 Transformers",
+    )
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default="esb/datasets",
+        help="Dataset path. By default, it is `esb/datasets`",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        help="Dataset name. *E.g.* `'librispeech_asr` for the LibriSpeech ASR dataset, or `'common_voice'` for Common Voice. The full list of dataset names "
+        "can be found at `https://huggingface.co/datasets/esb/datasets`",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        help="Split of the dataset. *E.g.* `'validation`' for the dev split, or `'test'` for the test split.",
+    )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=-1,
+        help="The device to run the pipeline on. -1 for CPU (default), 0 for the first GPU and so on.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=16,
+        help="Number of samples to go through each streamed batch.",
+    )
+    parser.add_argument(
+        "--num_beams",
+        type=int,
+        default=1,
+        help="Number of beams for beam search.",
+    )
+    parser.add_argument(
+        "--max_eval_samples",
+        type=int,
+        default=None,
+        help="Number of samples to be evaluated. Put a lower number e.g. 64 for testing this script.",
+    )
+    parser.add_argument(
+        "--no-streaming",
+        dest="streaming",
+        action="store_false",
+        help="Choose whether you'd like to download the entire dataset or stream it during the evaluation.",
+    )
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=None,
+        help="Maximum number of tokens to generate (for auto-regressive models).",
+    )
+    parser.add_argument(
+        "--warmup_steps",
+        type=int,
+        default=2,
+        help="Number of warm-up steps to run before launching the timed runs.",
+    )
+    
+    args = parser.parse_args()
+    parser.set_defaults(streaming=False)
+
+    main(args)

--- a/voxtral/run_eval.py
+++ b/voxtral/run_eval.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import soundfile
-import librosa
 import tempfile
 import torch
 from transformers import AutoProcessor, VoxtralForConditionalGeneration
@@ -19,7 +18,7 @@ def main(args):
     processor = AutoProcessor.from_pretrained(args.model_id)
     model = VoxtralForConditionalGeneration.from_pretrained(args.model_id, torch_dtype=torch.bfloat16, device_map=args.device)
 
-    def benchmark(batch):
+    def benchmark(batch, min_new_tokens=500):
         # Load audio inputs
         audios = [audio["array"] for audio in batch["audio"]]
         minibatch_size = len(audios)
@@ -38,14 +37,13 @@ def main(args):
         inputs = inputs.to(args.device, dtype=torch.bfloat16)
 
         start_time = time.time()
-        outputs = model.generate(**inputs, max_new_tokens=500)
+        outputs = model.generate(**inputs, max_new_tokens=500, do_sample=False)
 
         output_text = processor.batch_decode(outputs[:, inputs.input_ids.shape[1]:], skip_special_tokens=True)
         # END TIMING
         runtime = time.time() - start_time
 
         for p in paths:
-            print(f'Deleting {p}')
             os.unlink(p)
 
 

--- a/voxtral/run_voxtral.sh
+++ b/voxtral/run_voxtral.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+export PYTHONPATH="..":$PYTHONPATH
+
+MODEL_IDs=("mistralai/Voxtral-Mini-3B-2507")
+
+BATCH_SIZE=48
+
+num_models=${#MODEL_IDs[@]}
+
+for (( i=0; i<${num_models}; i++ ));
+do
+    MODEL_ID=${MODEL_IDs[$i]}
+
+    python run_eval.py \
+         --model_id=${MODEL_ID} \
+         --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+         --dataset="voxpopuli" \
+         --split="test" \
+         --device=0 \
+         --batch_size=${BATCH_SIZE} \
+         --max_eval_samples=-1
+
+    python run_eval.py \
+         --model_id=${MODEL_ID} \
+         --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+         --dataset="ami" \
+         --split="test" \
+         --device=0 \
+         --batch_size=${BATCH_SIZE} \
+         --max_eval_samples=-1
+
+    python run_eval.py \
+         --model_id=${MODEL_ID} \
+         --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+         --dataset="earnings22" \
+         --split="test" \
+         --device=0 \
+         --batch_size=${BATCH_SIZE} \
+         --max_eval_samples=-1
+
+    uv run python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="gigaspeech" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    uv run python run_eval.py \
+         --model_id=${MODEL_ID} \
+         --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+         --dataset="librispeech" \
+         --split="test.clean" \
+         --device=0 \
+         --batch_size=${BATCH_SIZE} \
+         --max_eval_samples=-1
+
+    python run_eval.py \
+         --model_id=${MODEL_ID} \
+         --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+         --dataset="librispeech" \
+         --split="test.other" \
+         --device=0 \
+         --batch_size=${BATCH_SIZE} \
+         --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="spgispeech" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+     python run_eval.py \
+         --model_id=${MODEL_ID} \
+         --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+         --dataset="tedlium" \
+         --split="test" \
+         --device=0 \
+         --batch_size=${BATCH_SIZE} \
+         --max_eval_samples=-1
+
+    # Evaluate results
+    RUNDIR=`pwd` && \
+    cd ../normalizer && \
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')" && \
+    cd $RUNDIR
+
+done

--- a/voxtral/run_voxtral.sh
+++ b/voxtral/run_voxtral.sh
@@ -2,7 +2,7 @@
 
 export PYTHONPATH="..":$PYTHONPATH
 
-MODEL_IDs=("mistralai/Voxtral-Mini-3B-2507")
+MODEL_IDs=("mistralai/Voxtral-Mini-3B-2507" "mistralai/Voxtral-Mini-3B-2507")
 
 BATCH_SIZE=48
 


### PR DESCRIPTION
For mini:
```

mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 16.31 %, RTFx = 107.11
mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 10.65 %, RTFx = 202.64
mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 10.24 %, RTFx = 164.75
mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 1.89 %, RTFx = 200.71
mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 4.08 %, RTFx = 195.13
mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 2.37 %, RTFx = 235.66
mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 3.70 %, RTFx = 160.19
mistralai/Voxtral-Mini-3B-2507 | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 7.14 %, RTFx = 209.18

********************************************************************************
Composite Results:
********************************************************************************
mistralai/Voxtral-Mini-3B-2507: WER = 7.05 %

```

And for the Small:

```
Filtering models by id: mistralai/Voxtral-Small-24B-2507
********************************************************************************
Results per dataset:
********************************************************************************
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 15.38 %, RTFx = 44.78
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 10.51 %, RTFx = 93.12
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 9.81 %, RTFx = 78.56
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 1.59 %, RTFx = 98.25
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 3.26 %, RTFx = 88.50
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 2.02 %, RTFx = 110.57
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 3.48 %, RTFx = 88.53
mistralai/Voxtral-Small-24B-2507 | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 6.95 %, RTFx = 109.49

********************************************************************************
Composite Results:
********************************************************************************
mistralai/Voxtral-Small-24B-2507: WER = 6.63 %
```



For the datasets that are both in the [[techreport]](https://arxiv.org/abs/2507.13264)  and in the benchmark, the numbers are close-ish:
<img width="567" height="219" alt="image" src="https://github.com/user-attachments/assets/b7cea31f-4dd4-4a20-8bc4-954674064f83" />


***NB*** Now, the RTF might not be representative since I drop files on disk for the simplicity. And I do that because feeding in files seems the standard interface for the model in HF - while passing tensors is supported, I didn't figure out immediately what values of the format I am supposed to feed in. Whatever, shouldn't affect the WER values.